### PR TITLE
Docs: Swagger production server = api.map-action.com (AWS)

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -157,7 +157,7 @@ SPECTACULAR_SETTINGS = {
     'CONTACT': {'name': 'Map Action', 'url': 'https://github.com/223MapAction'},
     'LICENSE': {'name': 'Proprietary'},
     'SERVERS': [
-        {'url': 'https://backend-production-0726b.up.railway.app', 'description': 'Production (Railway)'},
+        {'url': 'https://api.map-action.com', 'description': 'Production (AWS)'},
         {'url': 'http://localhost:8000', 'description': 'Dev local (daphne direct)'},
         {'url': 'http://localhost', 'description': 'Dev local (via nginx)'},
     ],


### PR DESCRIPTION
Updates the OpenAPI `SERVERS` entry shown in Swagger UI (`/MapApi/schema/swagger-ui/`) from the retired Railway URL to the live AWS production host `https://api.map-action.com`. Docs-only, one line.