### PR TITLE
Fix prod WebSockets (nginx upgrade) + incident list ordering

### DIFF
--- a/Mapapi/views/incident.py
+++ b/Mapapi/views/incident.py
@@ -201,7 +201,7 @@ class IncidentByZoneAPIView(generics.CreateAPIView):
                     'org_assignments__organisation',
                     'collaboration_set__user__organisation_member',
                 )
-                .order_by('-pk')
+                .order_by('-created_at')
             )
             item = visible_incidents_qs(base, request.user)
             serializer = IncidentGetSerializer(item, many=True)
@@ -390,7 +390,7 @@ class IncidentAPIListView(generics.CreateAPIView):
                 'org_assignments__organisation',
                 'collaboration_set__user__organisation_member',
             )
-            .order_by('-pk')
+            .order_by('-created_at')
         )
         items = visible_incidents_qs(base, request.user)
         # Recherche + filtres (onglet incidents) : ?search= (titre/description/zone),

--- a/services/nginx/conf.d/default.conf
+++ b/services/nginx/conf.d/default.conf
@@ -1,3 +1,9 @@
+# Map pour l'upgrade WebSocket (Connection: upgrade uniquement quand demandé).
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
 server {
     listen 80;
     server_name api.map-action.com www.api.map-action.com;
@@ -8,6 +14,11 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        # Support WebSocket (Channels temps réel : activity-feed, discussion, tasks, ...)
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 3600s;
     }
 
     client_max_body_size 64M;


### PR DESCRIPTION
Two prod-only issues after cutover (app logic is already identical to dev; these are infra + a UUID side-effect).

**1. WebSockets (all `wss://` broken).** Prod's nginx serves via `default.conf`, which lacked the WebSocket-upgrade block that dev's `local.conf` has, so `/ws/` was proxied as plain HTTP → daphne never got the handshake. Added the `map $http_upgrade` + `proxy_http_version 1.1` + `Upgrade`/`Connection` headers. Verified live: `wss://api.map-action.com/ws/activity-feed/` now returns **101 Switching Protocols**. (Already applied+reloaded on the server; this PR persists it across deploys.)

**2. Incident list out of creation order.** `IncidentAPIListView`/`IncidentByZoneAPIView` sorted by `-pk`; that was newest-first with the old integer IDs but is random now that PKs are UUIDs. Changed to `-created_at`.

Impact-page 500 and English activity feed were separate **data** issues (old merged prod rows) and are handled by migrating the data to dev shape — no code change.