### PR TITLE
Fix prod: WebSockets, incident ordering, accent-insensitive search

### DIFF
--- a/Mapapi/migrations/0008_unaccent_extension.py
+++ b/Mapapi/migrations/0008_unaccent_extension.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.operations import UnaccentExtension
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Active l'extension Postgres `unaccent` (recherche insensible aux accents).
+
+    Crée l'extension dans le schéma `public` (présent dans le search_path en dev
+    comme en prod) afin que le lookup Django `__unaccent` — qui appelle
+    `UNACCENT()` sans qualifier le schéma — se résolve dans tous les environnements.
+    Idempotent (CREATE EXTENSION IF NOT EXISTS).
+    """
+
+    dependencies = [
+        ('Mapapi', '0007_notification_notif_type'),
+    ]
+
+    operations = [
+        UnaccentExtension(),
+    ]

--- a/Mapapi/views/collaboration.py
+++ b/Mapapi/views/collaboration.py
@@ -22,7 +22,7 @@ from ..serializer import CollaborationSerializer, CollaborationEnrichedSerialize
 from ..permissions import IsOrgAdmin, IsOrgOperative
 from ..roles import is_super_admin, is_org_admin, is_bureau_agent
 from ..Send_mails import send_email
-from .common import CustomPageNumberPagination
+from .common import CustomPageNumberPagination, deaccent
 
 
 def collaboration_scope_q(user, scope):
@@ -175,12 +175,13 @@ class CollaborationDashboardView(generics.ListAPIView):
         # --- Recherche textuelle ---
         search = self.request.query_params.get('search', '').strip()
         if search:
+            ua = deaccent(search)
             qs = qs.filter(
-                Q(incident__title__icontains=search)
-                | Q(user__organisation__icontains=search)
-                | Q(user__organisation_member__name__icontains=search)
-                | Q(role__icontains=search)
-                | Q(incident__zone__icontains=search)
+                Q(incident__title__unaccent__icontains=ua)
+                | Q(user__organisation__unaccent__icontains=ua)
+                | Q(user__organisation_member__name__unaccent__icontains=ua)
+                | Q(role__unaccent__icontains=ua)
+                | Q(incident__zone__unaccent__icontains=ua)
             )
 
         return qs

--- a/Mapapi/views/common.py
+++ b/Mapapi/views/common.py
@@ -7,6 +7,7 @@ Imported by each domain view module with:
 import logging
 import random
 import string
+import unicodedata
 
 from django.http import JsonResponse
 from django.middleware.csrf import get_token
@@ -60,6 +61,16 @@ def get_random_digits(length=6):
 def get_csrf_token(request):
     csrf_token = get_token(request)
     return JsonResponse({'csrf_token': csrf_token})
+
+
+def deaccent(text):
+    """Retire les accents/diacritiques d'un terme de recherche (côté valeur).
+
+    À combiner avec le lookup ``__unaccent`` côté colonne (extension Postgres
+    ``unaccent``) : la recherche devient insensible à la casse ET aux accents
+    (« secheresse » trouve « Sécheresse », et inversement).
+    """
+    return ''.join(c for c in unicodedata.normalize('NFKD', text or '') if not unicodedata.combining(c))
 
 
 # Constant preserved from legacy views.py

--- a/Mapapi/views/incident.py
+++ b/Mapapi/views/incident.py
@@ -46,7 +46,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 from ..services.model_chat_client import ask_model_chat
-from .common import CustomPageNumberPagination, IncidentPagination, FieldReportPagination
+from .common import CustomPageNumberPagination, IncidentPagination, FieldReportPagination, deaccent
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.hashers import check_password
 from .. import roles as web_roles
@@ -398,8 +398,9 @@ class IncidentAPIListView(generics.CreateAPIView):
         p = request.query_params
         search = (p.get('search') or '').strip()
         if search:
+            ua = deaccent(search)
             items = items.filter(
-                Q(title__icontains=search) | Q(description__icontains=search) | Q(zone__icontains=search)
+                Q(title__unaccent__icontains=ua) | Q(description__unaccent__icontains=ua) | Q(zone__unaccent__icontains=ua)
             )
         etat = p.get('etat') or p.get('status')
         if etat:
@@ -585,10 +586,11 @@ class OrgIncidentsView(generics.ListAPIView):
         p = self.request.query_params
         search = (p.get('search') or '').strip()
         if search:
+            ua = deaccent(search)
             qs = qs.filter(
-                Q(title__icontains=search)
-                | Q(description__icontains=search)
-                | Q(zone__icontains=search)
+                Q(title__unaccent__icontains=ua)
+                | Q(description__unaccent__icontains=ua)
+                | Q(zone__unaccent__icontains=ua)
             )
         status_etat = p.get('status') or p.get('etat')
         if status_etat:

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.postgres',  # active le lookup __unaccent (recherche sans accents)
     'corsheaders',
     'rest_framework',
     'Mapapi',


### PR DESCRIPTION
WebSocket nginx upgrade (verified live: wss -> 101), incident ordering -pk->-created_at (UUID PKs), and case/accent-insensitive search on incidents+collaboration (Postgres unaccent, migration 0008 + django.contrib.postgres + deaccent()). Verified on dev. Impact-500 and English-activity were separate data fixes already applied.