### PR TITLE
Super admin: full access to tasks, discussion & collaboration of any incident

### DIFF
--- a/Mapapi/permissions.py
+++ b/Mapapi/permissions.py
@@ -72,6 +72,10 @@ class IsIncidentLeader(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        # Le super admin (plateforme) a un accès complet aux collaborations,
+        # tâches et discussions de tout incident, sans être leader/contributeur.
+        if is_super_admin(request.user):
+            return True
         incident = _get_incident_from_view(view, request)
         if incident is None:
             # si pas d'incident dans l'URL, on délègue à has_object_permission
@@ -86,6 +90,8 @@ class IsIncidentLeader(BasePermission):
         return incident.taken_by_id == request.user.id
 
     def has_object_permission(self, request, view, obj):
+        if is_super_admin(request.user):
+            return True
         incident = getattr(obj, 'incident', obj if isinstance(obj, Incident) else None)
         if incident is None:
             return False
@@ -107,6 +113,10 @@ class IsIncidentCollaborator(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        # Le super admin (plateforme) a un accès complet aux collaborations,
+        # tâches et discussions de tout incident, sans être leader/contributeur.
+        if is_super_admin(request.user):
+            return True
         incident = _get_incident_from_view(view, request)
         if incident is None:
             return True
@@ -119,6 +129,8 @@ class IsIncidentCollaborator(BasePermission):
         ).exists()
 
     def has_object_permission(self, request, view, obj):
+        if is_super_admin(request.user):
+            return True
         incident = getattr(obj, 'incident', obj if isinstance(obj, Incident) else None)
         if incident is None:
             return False
@@ -143,6 +155,10 @@ class IsIncidentContributor(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        # Le super admin (plateforme) a un accès complet aux collaborations,
+        # tâches et discussions de tout incident, sans être leader/contributeur.
+        if is_super_admin(request.user):
+            return True
         # Les méthodes de lecture restent autorisées pour tous les collaborateurs
         if request.method in SAFE_METHODS:
             return IsIncidentCollaborator().has_permission(request, view)
@@ -171,6 +187,10 @@ class IsIncidentLeaderOrContributor(BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        # Le super admin (plateforme) a un accès complet aux collaborations,
+        # tâches et discussions de tout incident, sans être leader/contributeur.
+        if is_super_admin(request.user):
+            return True
         if request.method in SAFE_METHODS:
             return IsIncidentCollaborator().has_permission(request, view)
         incident = _get_incident_from_view(view, request)

--- a/Mapapi/views/message.py
+++ b/Mapapi/views/message.py
@@ -23,6 +23,7 @@ from drf_spectacular.types import OpenApiTypes
 
 from ..serializer import *
 from ..models import Collaboration, Incident, COLLAB_ROLE_LEADER
+from ..roles import is_super_admin
 from .common import CustomPageNumberPagination
 
 
@@ -491,8 +492,10 @@ class DiscussionMessageView(generics.ListCreateAPIView):
         incident_id = self.kwargs.get('incident_id')
         user = self.request.user
 
-        # Vérifier que l'utilisateur est collaborateur accepté
-        self._get_user_collaboration(incident_id, user)
+        # Vérifier que l'utilisateur est collaborateur accepté (le super admin a
+        # un accès complet en lecture à toute discussion).
+        if not is_super_admin(user):
+            self._get_user_collaboration(incident_id, user)
 
         # Chat de groupe : tous les messages de l'incident
         return DiscussionMessage.objects.filter(
@@ -555,8 +558,13 @@ class DiscussionMessageView(generics.ListCreateAPIView):
         incident_id = self.kwargs.get('incident_id')
         user = self.request.user
 
-        collaboration = self._get_user_collaboration(incident_id, user)
-        incident = collaboration.incident
+        # Le super admin peut poster sans être collaborateur ; sinon on exige
+        # une collaboration acceptée.
+        if is_super_admin(user):
+            incident = Incident.objects.get(pk=incident_id)
+        else:
+            collaboration = self._get_user_collaboration(incident_id, user)
+            incident = collaboration.incident
 
         if incident.etat == "resolved":
             raise ValidationError("Cet incident est résolu, la discussion est terminée.")


### PR DESCRIPTION
Fixes FE report: the super admin could not create/modify/delete **tasks** nor open the **discussion** in an incident's collaboration (403 'Seul le leader ou un contributeur…' / 404 'Vous ne participez pas…').

Root cause: the collaboration permission classes (`IsIncidentLeader`, `IsIncidentCollaborator`, `IsIncidentContributor`, `IsIncidentLeaderOrContributor`) and the discussion view had **no super_admin bypass** — they only recognised leader/contributor/member. Added `is_super_admin` short-circuits (permissions + `DiscussionMessageView.get_queryset`/`perform_create`).

Verified on dev as super_admin: task create → 201, modify → 200, delete → 204, discussion → 200.