### PR TITLE
Map endpoint: add optional ?country filter

### DIFF
--- a/Mapapi/views/incident.py
+++ b/Mapapi/views/incident.py
@@ -1289,6 +1289,15 @@ class IncidentFilterView(APIView):
         elif filter_type == 'custom_range' and custom_start and custom_end:
             incidents = incidents.filter(created_at__date__range=[custom_start, custom_end])
 
+        # --- Filtre pays (optionnel) ---
+        # Pays géocodé de la prédiction IA de l'incident (Prediction.country).
+        # Ex. ?country=Mali ou ?country=mali ou ?country=burkina_faso (insensible à la
+        # casse et aux underscores) → seulement les incidents localisés dans ce pays.
+        # Le front peut passer l'`intervention_country` de l'org du user connecté.
+        country = (request.query_params.get('country') or '').replace('_', ' ').strip()
+        if country:
+            incidents = incidents.filter(prediction__country__iexact=country)
+
         # Pagination OPT-IN pour un chargement progressif de la carte : si ?page ou
         # ?page_size est fourni, on renvoie une page {count, next, previous, results}
         # (marqueurs légers IncidentMapSerializer, ?page_size plafonné à 100) ; sinon


### PR DESCRIPTION
Adds an optional `?country` filter to `/incident-filter/` — filters incidents by their geocoded prediction country (case/underscore-insensitive, e.g. `mali` or `burkina_faso` match `Mali` / `Burkina Faso`). Combines with `scope` and pagination. Verified on dev: `country=mali` → 46, `Burkina Faso` → 0. One file, one hunk.