### PR TITLE
Fix celery_beat crash-loop: add missing env (SECRET_KEY, DB, etc.)

### DIFF
--- a/_cd_pipeline.yml
+++ b/_cd_pipeline.yml
@@ -154,6 +154,22 @@ services:
             - ~/celery_store:/celery_data
         depends_on:
             - redis
+        env_file:
+            - .env
+        environment:
+            - ALLOWED_HOSTS=${ALLOWED_HOSTS}
+            - DB_HOST=${DB_HOST}
+            - POSTGRES_USER=${POSTGRES_USER}
+            - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+            - POSTGRES_DB=${POSTGRES_DB}
+            - SECRET_KEY=${SECRET_KEY}
+            - SUPABASE_URL=${SUPABASE_URL}
+            - SUPABASE_ANON_KEY=${SUPABASE_ANON_KEY}
+            - USE_SUPABASE_STORAGE=${USE_SUPABASE_STORAGE}
+            - MODEL_DEPLOY_ANALYZE_URL=${MODEL_DEPLOY_ANALYZE_URL}
+            - MODEL_DEPLOY_TIMEOUT=${MODEL_DEPLOY_TIMEOUT}
+            - MODEL_DEPLOY_CHAT_URL=${MODEL_DEPLOY_CHAT_URL}
+            - MODEL_DEPLOY_CHAT_TIMEOUT=${MODEL_DEPLOY_CHAT_TIMEOUT}
         networks:
             micro-services-network:
                 ipv4_address: 192.168.0.9


### PR DESCRIPTION
`celery_beat` was exiting with `ImproperlyConfigured: SECRET_KEY must not be empty` — its `celery-beat` service in `_cd_pipeline.yml` had no `env_file`/`environment` block (unlike `celery`/worker and `api-server`). Added the same env block. Takes effect on next deploy (recreates the container with the env).