### PR TITLE
Add GET /organisations/others/ (orgs except own, paginated, searchable, not field-agent)

### DIFF
--- a/Mapapi/urls.py
+++ b/Mapapi/urls.py
@@ -33,7 +33,7 @@ from .views.collaboration import (
 from .views.organisation import (
     OrganisationMemberListView, OrganisationMemberCreateView,
     OrganisationMemberDetailView, OrganisationDetailView, OrganisationStatsView,
-    FieldAgentCreateView, StaffAccountCreateView,
+    FieldAgentCreateView, StaffAccountCreateView, OtherOrganisationsView,
 )
 from .ivr_views import (
     TwilioIVRWebhook, SelectZoneView, SelectCategoryView,
@@ -61,6 +61,7 @@ urlpatterns = [
     path('tenant-config/', TenantConfigView.as_view(), name='tenant_config'),
     path('organisations/', OrganisationViewSet.as_view(), name='organisation-list-create'),
     path('organisations/stats/', OrganisationStatsView.as_view(), name='organisation-stats'),
+    path('organisations/others/', OtherOrganisationsView.as_view(), name='organisations-others'),
     path('organisations/<uuid:pk>/', OrganisationViewSet.as_view(), name='organisation-detail'),
     path('organisations/<uuid:pk>/detail/', OrganisationDetailView.as_view(), name='organisation-detail-enriched'),
     # --- Gestion des membres d'une organisation ---

--- a/Mapapi/views/organisation.py
+++ b/Mapapi/views/organisation.py
@@ -3,7 +3,7 @@ import string
 import random
 import logging
 
-from Mapapi.views.common import CustomPageNumberPagination
+from Mapapi.views.common import CustomPageNumberPagination, deaccent
 from django.db.models import Count, Q
 
 logger = logging.getLogger(__name__)
@@ -172,6 +172,61 @@ class OrganisationViewSet(generics.ListCreateAPIView, generics.RetrieveUpdateDes
                 status=status.HTTP_403_FORBIDDEN,
             )
         return super().update(request, *args, **kwargs)
+
+
+class NotFieldAgent(permissions.BasePermission):
+    """Autorise tout utilisateur authentifié SAUF l'agent de terrain (mobile-only)."""
+
+    message = "Non accessible à l'agent de terrain."
+
+    def has_permission(self, request, view):
+        u = request.user
+        if not (u and u.is_authenticated):
+            return False
+        return is_super_admin(u) or getattr(u, 'org_role', None) != ORG_ROLE_FIELD
+
+
+@extend_schema(
+    tags=['Organisations & Membres'],
+    operation_id='organisations_others_list',
+    summary='Autres organisations (hors la mienne)',
+    description="Liste paginée des organisations SAUF celle de l'utilisateur connecté. "
+                "Recherche `?search=` (nom / acronyme / sous-domaine / pays, insensible à la "
+                "casse et aux accents). Pagination `?page`/`?page_size` (chargement « en "
+                "savoir plus »). Accessible à tous les rôles dashboard SAUF l'agent de terrain.",
+    parameters=[
+        OpenApiParameter('search', OpenApiTypes.STR, OpenApiParameter.QUERY, required=False,
+                         description="Recherche nom / acronyme / sous-domaine / pays."),
+        OpenApiParameter('page', OpenApiTypes.INT, OpenApiParameter.QUERY, required=False,
+                         description="Numéro de page (chargement progressif « en savoir plus »)."),
+        OpenApiParameter('page_size', OpenApiTypes.INT, OpenApiParameter.QUERY, required=False,
+                         description="Taille de page."),
+    ],
+    responses={200: OrganisationSerializer(many=True)},
+)
+class OtherOrganisationsView(generics.ListAPIView):
+    """GET /organisations/others/ — organisations autres que celle du user connecté."""
+
+    serializer_class = OrganisationSerializer
+    permission_classes = [NotFieldAgent]
+    pagination_class = CustomPageNumberPagination
+
+    def get_queryset(self):
+        user = self.request.user
+        qs = Organisation.objects.all().order_by('-created_at')
+        own = getattr(user, 'organisation_member_id', None)
+        if own:
+            qs = qs.exclude(id=own)
+        search = (self.request.query_params.get('search') or '').strip()
+        if search:
+            ua = deaccent(search)
+            qs = qs.filter(
+                Q(name__unaccent__icontains=ua)
+                | Q(acronym__unaccent__icontains=ua)
+                | Q(subdomain__unaccent__icontains=ua)
+                | Q(intervention_country__unaccent__icontains=ua)
+            )
+        return qs
 
 
 @extend_schema(


### PR DESCRIPTION
FE request: an endpoint returning organisations EXCEPT the connected user's own, with pagination (load-more) + `search`, accessible to all dashboard roles except the field agent.

`GET /MapApi/organisations/others/`
- Excludes the caller's `organisation_member`.
- `?search=` on name/acronym/subdomain/intervention_country (case + accent-insensitive via `unaccent`).
- Paginated `?page`/`?page_size` ({count,next,previous,results}).
- Permission: authenticated, any role EXCEPT field agent (→ 403).
Verified on dev (super_admin 4 / org_admin excl-own 3 / field_agent 403 / search / pagination).