### PR TITLE
Enrich PartnerSuggestion serializer with incident card fields

### DIFF
--- a/Mapapi/serializer.py
+++ b/Mapapi/serializer.py
@@ -933,6 +933,18 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
         write_only=True,
         required=False,
     )
+    # --- Champs de l'incident pour l'affichage des cartes (parité avec
+    # CollaborationSerializer). Sans eux, les demandes de partenariat s'affichaient
+    # dans l'onglet « Demandes » sans photo, description ni détails — contrairement
+    # aux cartes de collaboration. On expose donc EXACTEMENT les mêmes raccourcis.
+    incident_photo = serializers.ImageField(source='incident.photo', read_only=True)
+    incident_thumbnail = serializers.ImageField(source='incident.thumbnail', read_only=True)
+    incident_description = serializers.CharField(
+        source='incident.description', read_only=True, default=None
+    )
+    incident_zone = serializers.CharField(source='incident.zone', read_only=True, default=None)
+    incident_etat = serializers.CharField(source='incident.etat', read_only=True, default=None)
+    incident_details = IncidentSerializer(source='incident', read_only=True)
 
     class Meta:
         model = PartnerSuggestion


### PR DESCRIPTION
## Problem
In the frontend **Collaborations → Demandes** tab, cards sourced from **partner suggestions** (`/my-suggestions/received/`, `/my-suggestions/sent/`) rendered empty — no photo, no description, no incident details — while cards sourced from collaboration requests (`/collaboration/`) rendered fully. The two lists are merged in the same tab, so the suggestion cards looked broken.

## Root cause
`PartnerSuggestionSerializer` exposed only `incident_title`, whereas `CollaborationSerializer` also exposes `incident_photo`, `incident_thumbnail`, `incident_details`, etc. The FE renders both card types with the same component, so suggestion items had nothing to show.

## Fix
Add to `PartnerSuggestionSerializer` the same incident card fields as `CollaborationSerializer` (all read-only, additive — no breaking change):
`incident_photo`, `incident_thumbnail`, `incident_description`, `incident_zone`, `incident_etat`, `incident_details`.

Verified on prod: the incident data + storage files (photo/thumbnail) already resolve (HTTP 200); only the serializer was missing the fields.

Docs updated in `Dashboardv2/BACKEND_API.md` (+ `.fr.md`).