### PR TITLE
PartnerSuggestion: sender/receiver direction fields + invited org can accept/reject

### DIFF
--- a/Mapapi/serializer.py
+++ b/Mapapi/serializer.py
@@ -945,6 +945,18 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
     incident_zone = serializers.CharField(source='incident.zone', read_only=True, default=None)
     incident_etat = serializers.CharField(source='incident.etat', read_only=True, default=None)
     incident_details = IncidentSerializer(source='incident', read_only=True)
+    # --- Sens de la demande RELATIF à l'utilisateur courant (#FE) ---
+    # Sur une même liste (« Demandes »), chaque item indique si l'utilisateur
+    # connecté est l'émetteur (il a invité) ou le destinataire (il a été invité) :
+    #   direction   : 'sent' (j'ai invité) | 'received' (j'ai été invité) | 'other'
+    #   is_sender   : je suis l'émetteur de l'invitation
+    #   is_receiver : je suis l'organisation invitée
+    #   can_respond : je suis le destinataire ET la demande est en attente
+    #                 -> c'est à MOI d'accepter / refuser (afficher les boutons)
+    direction = serializers.SerializerMethodField()
+    is_sender = serializers.SerializerMethodField()
+    is_receiver = serializers.SerializerMethodField()
+    can_respond = serializers.SerializerMethodField()
 
     class Meta:
         model = PartnerSuggestion
@@ -966,6 +978,43 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
         if not u:
             return None
         return f"{u.first_name or ''} {u.last_name or ''}".strip() or u.email
+
+    def _current_user(self):
+        request = self.context.get('request')
+        user = getattr(request, 'user', None)
+        if user is not None and getattr(user, 'is_authenticated', False):
+            return user
+        return None
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_direction(self, obj) -> str | None:
+        u = self._current_user()
+        if u is None:
+            return None
+        if obj.suggested_by_id == u.id:
+            return 'sent'
+        if obj.suggested_partner_id == u.id:
+            return 'received'
+        return 'other'
+
+    def get_is_sender(self, obj) -> bool:
+        u = self._current_user()
+        return bool(u is not None and obj.suggested_by_id == u.id)
+
+    def get_is_receiver(self, obj) -> bool:
+        u = self._current_user()
+        return bool(u is not None and obj.suggested_partner_id == u.id)
+
+    def get_can_respond(self, obj) -> bool:
+        # Seul le DESTINATAIRE (organisation invitée) accepte/refuse, tant que la
+        # demande est en attente. C'est ce flag qui pilote l'affichage des boutons
+        # « Accepter / Refuser » côté front.
+        u = self._current_user()
+        return bool(
+            u is not None
+            and obj.suggested_partner_id == u.id
+            and obj.status == SUGGESTION_PENDING
+        )
 
     def get_unique_together_validators(self):
         # Le modèle a unique_together (incident, suggested_partner). DRF en déduit

--- a/Mapapi/views/partner_suggestion.py
+++ b/Mapapi/views/partner_suggestion.py
@@ -14,12 +14,37 @@ from rest_framework import serializers
 from ..models import (
     Incident, PartnerSuggestion, Collaboration,
     SUGGESTION_PENDING, SUGGESTION_ACCEPTED, SUGGESTION_REJECTED,
+    COLLAB_ROLE_LEADER,
 )
 from ..serializer import PartnerSuggestionSerializer
 from ..permissions import (
-    IsIncidentCollaborator, IsIncidentContributor, IsIncidentLeader,
+    IsIncidentCollaborator, IsIncidentContributor,
     IsIncidentLeaderOrContributor,
 )
+from ..roles import is_super_admin
+
+
+def _can_decide_suggestion(user, suggestion):
+    """Qui peut accepter/refuser une suggestion de partenariat.
+
+    Le DESTINATAIRE (l'organisation invitée = ``suggested_partner``) décide : c'est
+    SA décision de rejoindre l'incident, exactement comme le veut le flux « le
+    leader invite → l'org invitée accepte/refuse ». Le leader de l'incident et le
+    super admin conservent aussi ce droit (rétro-compatibilité avec le flux
+    historique « suggestion adressée au leader »).
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if suggestion.suggested_partner_id == user.id:
+        return True
+    if is_super_admin(user):
+        return True
+    incident = suggestion.incident
+    if incident.taken_by_id == user.id:
+        return True
+    return Collaboration.objects.filter(
+        incident=incident, user=user, role=COLLAB_ROLE_LEADER, status='accepted',
+    ).exists()
 
 
 @extend_schema_view(get=extend_schema(
@@ -42,9 +67,9 @@ class MyReceivedSuggestionsView(generics.ListAPIView):
     GET /my-suggestions/received/  — Liste les suggestions où JE suis le partenaire proposé.
 
     Filtre optionnel via ?status=pending|accepted|rejected.
-    L'utilisateur peut ensuite décider d'accepter/refuser via les endpoints
-    /incidents/<id>/suggestions/<pk>/accept|reject/ (s'il est leader de
-    l'incident concerné).
+    En tant que destinataire (organisation invitée), l'utilisateur décide
+    d'accepter/refuser via /incidents/<id>/suggestions/<pk>/accept|reject/
+    (cf. le flag `can_respond` renvoyé sur chaque item).
     """
     serializer_class = PartnerSuggestionSerializer
     permission_classes = [IsAuthenticated]
@@ -215,7 +240,8 @@ class PartnerSuggestionDetailView(generics.RetrieveAPIView):
     description=(
         "Accepte une suggestion en attente : crée (ou met à jour) une `Collaboration` "
         "`accepted` pour le partenaire avec le rôle suggéré, et passe la suggestion à "
-        "`accepted`. Réservé au leader (`IsIncidentLeader`)."
+        "`accepted`. Réservé à l'organisation invitée (`suggested_partner`), au leader "
+        "de l'incident ou au super admin."
     ),
     parameters=[
         OpenApiParameter('incident_id', OpenApiTypes.UUID, OpenApiParameter.PATH,
@@ -232,17 +258,24 @@ class PartnerSuggestionDetailView(generics.RetrieveAPIView):
 ))
 class PartnerSuggestionAcceptView(APIView):
     """POST /incidents/<incident_id>/suggestions/<pk>/accept/"""
-    permission_classes = [IsAuthenticated, IsIncidentLeader]
+    permission_classes = [IsAuthenticated]
 
     def post(self, request, incident_id, pk):
         try:
-            suggestion = PartnerSuggestion.objects.get(
+            suggestion = PartnerSuggestion.objects.select_related('incident').get(
                 pk=pk, incident_id=incident_id
             )
         except PartnerSuggestion.DoesNotExist:
             return Response(
                 {"error": "Suggestion non trouvée."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not _can_decide_suggestion(request.user, suggestion):
+            return Response(
+                {"error": "Seule l'organisation invitée (ou le leader) peut "
+                          "répondre à cette invitation."},
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         if suggestion.status != SUGGESTION_PENDING:
@@ -269,7 +302,7 @@ class PartnerSuggestionAcceptView(APIView):
         suggestion.status = SUGGESTION_ACCEPTED
         suggestion.save()
 
-        serializer = PartnerSuggestionSerializer(suggestion)
+        serializer = PartnerSuggestionSerializer(suggestion, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
@@ -278,8 +311,9 @@ class PartnerSuggestionAcceptView(APIView):
     operation_id='suggestions_reject',
     summary="Rejeter une suggestion",
     description=(
-        "Rejette une suggestion en attente : la passe à `rejected`. Réservé au leader "
-        "(`IsIncidentLeader`)."
+        "Rejette une suggestion en attente : la passe à `rejected`. Réservé à "
+        "l'organisation invitée (`suggested_partner`), au leader de l'incident ou au "
+        "super admin."
     ),
     parameters=[
         OpenApiParameter('incident_id', OpenApiTypes.UUID, OpenApiParameter.PATH,
@@ -296,17 +330,24 @@ class PartnerSuggestionAcceptView(APIView):
 ))
 class PartnerSuggestionRejectView(APIView):
     """POST /incidents/<incident_id>/suggestions/<pk>/reject/"""
-    permission_classes = [IsAuthenticated, IsIncidentLeader]
+    permission_classes = [IsAuthenticated]
 
     def post(self, request, incident_id, pk):
         try:
-            suggestion = PartnerSuggestion.objects.get(
+            suggestion = PartnerSuggestion.objects.select_related('incident').get(
                 pk=pk, incident_id=incident_id
             )
         except PartnerSuggestion.DoesNotExist:
             return Response(
                 {"error": "Suggestion non trouvée."},
                 status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not _can_decide_suggestion(request.user, suggestion):
+            return Response(
+                {"error": "Seule l'organisation invitée (ou le leader) peut "
+                          "répondre à cette invitation."},
+                status=status.HTTP_403_FORBIDDEN,
             )
 
         if suggestion.status != SUGGESTION_PENDING:
@@ -318,5 +359,5 @@ class PartnerSuggestionRejectView(APIView):
         suggestion.status = SUGGESTION_REJECTED
         suggestion.save()
 
-        serializer = PartnerSuggestionSerializer(suggestion)
+        serializer = PartnerSuggestionSerializer(suggestion, context={"request": request})
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Context
Follow-up to #57. The frontend **Demandes** tab merges sent + received partner suggestions in one list and needs to know, per item, whether the current user **sent** the invitation (leader inviting) or **received** it (invited org, who accepts/declines).

## Changes
**1. Viewer-relative fields on `PartnerSuggestionSerializer`** (read-only, computed from `request.user`):
- `direction`: `sent` (I invited) / `received` (I was invited) / `other`
- `is_sender`, `is_receiver`: booleans
- `can_respond`: true when I'm the invited org **and** status is `pending` → the FE shows Accept/Reject buttons only to the receiver.

**2. The invited org can now accept/reject.** The accept/reject endpoints required `IsIncidentLeader`, so the **receiver** (invited org) got a 403 — contradicting the intended flow ("leader invites → invited org decides"). Now `_can_decide_suggestion` allows the **`suggested_partner` (receiver)**, the **incident leader**, or a **super admin** (backward-compatible — nobody loses access).

Docs updated in `Dashboardv2/BACKEND_API.md` (+ `.fr.md`).