### PR TITLE
PartnerSuggestion: org-scope invitations (any admin of the invited org sees & responds)

### DIFF
--- a/Mapapi/serializer.py
+++ b/Mapapi/serializer.py
@@ -986,6 +986,21 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
             return user
         return None
 
+    def _is_recipient(self, obj, u):
+        """L'utilisateur est destinataire de l'invitation : soit le partenaire exact
+        résolu, soit un admin / agent de bureau de l'ORGANISATION invitée. Une
+        invitation est adressée à l'ORG : elle doit être visible par tous ses
+        responsables, pas seulement l'admin arbitraire tiré par .first()."""
+        if obj.suggested_partner_id == u.id:
+            return True
+        partner = obj.suggested_partner
+        partner_org_id = getattr(partner, 'organisation_member_id', None) if partner else None
+        user_org_id = getattr(u, 'organisation_member_id', None)
+        return bool(
+            partner_org_id and user_org_id and partner_org_id == user_org_id
+            and getattr(u, 'org_role', None) in (ORG_ROLE_ADMIN, ORG_ROLE_BUREAU)
+        )
+
     @extend_schema_field(OpenApiTypes.STR)
     def get_direction(self, obj) -> str | None:
         u = self._current_user()
@@ -993,7 +1008,7 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
             return None
         if obj.suggested_by_id == u.id:
             return 'sent'
-        if obj.suggested_partner_id == u.id:
+        if self._is_recipient(obj, u):
             return 'received'
         return 'other'
 
@@ -1003,16 +1018,16 @@ class PartnerSuggestionSerializer(serializers.ModelSerializer):
 
     def get_is_receiver(self, obj) -> bool:
         u = self._current_user()
-        return bool(u is not None and obj.suggested_partner_id == u.id)
+        return bool(u is not None and self._is_recipient(obj, u))
 
     def get_can_respond(self, obj) -> bool:
-        # Seul le DESTINATAIRE (organisation invitée) accepte/refuse, tant que la
-        # demande est en attente. C'est ce flag qui pilote l'affichage des boutons
-        # « Accepter / Refuser » côté front.
+        # Le DESTINATAIRE (l'organisation invitée : partenaire exact OU admin/bureau
+        # de l'org invitée) accepte/refuse tant que c'est en attente. Pilote
+        # l'affichage des boutons « Accepter / Refuser » côté front.
         u = self._current_user()
         return bool(
             u is not None
-            and obj.suggested_partner_id == u.id
+            and self._is_recipient(obj, u)
             and obj.status == SUGGESTION_PENDING
         )
 

--- a/Mapapi/views/partner_suggestion.py
+++ b/Mapapi/views/partner_suggestion.py
@@ -1,4 +1,5 @@
 """PartnerSuggestion endpoints: CRUD + actions accept / reject."""
+from django.db.models import Q
 from rest_framework import status, generics
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -14,7 +15,7 @@ from rest_framework import serializers
 from ..models import (
     Incident, PartnerSuggestion, Collaboration,
     SUGGESTION_PENDING, SUGGESTION_ACCEPTED, SUGGESTION_REJECTED,
-    COLLAB_ROLE_LEADER,
+    COLLAB_ROLE_LEADER, ORG_ROLE_ADMIN, ORG_ROLE_BUREAU,
 )
 from ..serializer import PartnerSuggestionSerializer
 from ..permissions import (
@@ -36,6 +37,14 @@ def _can_decide_suggestion(user, suggestion):
     if not user or not user.is_authenticated:
         return False
     if suggestion.suggested_partner_id == user.id:
+        return True
+    # Tout admin / agent de bureau de l'ORGANISATION invitée peut décider :
+    # l'invitation est adressée à l'org, pas au seul admin tiré par .first().
+    partner = suggestion.suggested_partner
+    partner_org_id = getattr(partner, 'organisation_member_id', None) if partner else None
+    user_org_id = getattr(user, 'organisation_member_id', None)
+    if (partner_org_id and user_org_id and partner_org_id == user_org_id
+            and getattr(user, 'org_role', None) in (ORG_ROLE_ADMIN, ORG_ROLE_BUREAU)):
         return True
     if is_super_admin(user):
         return True
@@ -75,9 +84,18 @@ class MyReceivedSuggestionsView(generics.ListAPIView):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
-        qs = PartnerSuggestion.objects.filter(
-            suggested_partner=self.request.user
-        ).select_related('incident', 'suggested_by').order_by('-created_at')
+        user = self.request.user
+        # Invitations dont JE suis le destinataire exact, OU adressées à MON
+        # organisation (résolues vers un de ses admins) si je suis admin/bureau :
+        # une invitation à l'org doit être visible par tous ses responsables, pas
+        # seulement l'admin arbitraire tiré par .first() lors de la résolution.
+        q = Q(suggested_partner=user)
+        org_id = getattr(user, 'organisation_member_id', None)
+        if org_id is not None and getattr(user, 'org_role', None) in (ORG_ROLE_ADMIN, ORG_ROLE_BUREAU):
+            q |= Q(suggested_partner__organisation_member_id=org_id)
+        qs = PartnerSuggestion.objects.filter(q).select_related(
+            'incident', 'suggested_by', 'suggested_partner'
+        ).order_by('-created_at')
         status_param = self.request.query_params.get('status')
         if status_param in (SUGGESTION_PENDING, SUGGESTION_ACCEPTED, SUGGESTION_REJECTED):
             qs = qs.filter(status=status_param)


### PR DESCRIPTION
## Problem
When you invite an **organisation** to collaborate, the backend resolves `suggested_organisation` to **one arbitrary admin** (`User.objects.filter(org, org_role=admin).first()`). If the org has several admins, only that one user's `/my-suggestions/received/` shows the invitation. So a real case: Unicef invited **Kaicedra Consulting SAS** (which has 3 org_admins); it resolved to *Aicha Toure*, and when the FE logged into Kaicedra as a **different** admin, the received list was empty.

## Fix — the invitation is addressed to the ORG
Make received/decision **org-scoped** (additive, backward-compatible):
- **`/my-suggestions/received/`**: also returns invitations sent to **my organisation** when I'm an `org_admin`/`bureau_agent` (not just those resolved to me exactly).
- **`can_respond` / `direction` / `is_receiver`** (serializer): true for any `org_admin`/`bureau_agent` of the invited org, not only the exact resolved user.
- **accept/reject** (`_can_decide_suggestion`): any `org_admin`/`bureau_agent` of the invited org can accept/reject (plus the exact partner, incident leader, super admin — unchanged).

No change to how `suggested_organisation` resolves; with org-scoping the specific resolved admin no longer matters.

Docs updated in `Dashboardv2/BACKEND_API.md` (+ `.fr.md`).