### PR TITLE
Mes collaborations: org-scope so accepted org-invitations appear for any org admin

### DIFF
--- a/Mapapi/views/collaboration.py
+++ b/Mapapi/views/collaboration.py
@@ -45,7 +45,16 @@ def collaboration_scope_q(user, scope):
         return Q()
     scope = (scope or 'all').lower()
     if scope == 'self':
-        return Q(user=user)
+        # « Mes collaborations » : les miennes + celles de MON organisation quand
+        # je suis admin / agent de bureau. Une collaboration issue d'une invitation
+        # à l'org est rattachée à l'admin résolu (le suggested_partner d'une
+        # suggestion acceptée) ; sans cet élargissement, l'admin qui a accepté — ou
+        # tout autre responsable de l'org — ne la verrait jamais ici.
+        q = Q(user=user)
+        org_id = getattr(user, 'organisation_member_id', None)
+        if org_id and (is_org_admin(user) or is_bureau_agent(user)):
+            q |= Q(user__organisation_member_id=org_id)
+        return q
     if scope == 'received':
         return Q(incident__taken_by=user) & ~Q(user=user)
     return Q(user=user) | Q(incident__taken_by=user)


### PR DESCRIPTION
## Problem
When an org accepts a partner suggestion, the accept endpoint creates the `Collaboration` attached to the **resolved partner** (`suggested_partner`, e.g. the org admin the invite resolved to — *Aicha Toure* for Kaicedra). But **"Mes collaborations"** (`/collaborations/dashboard/?scope=self`) filters `Q(user=user)` — the **exact** logged-in user. So when a *different* admin of the same org accepts (or just looks), the new collaboration — which belongs to the resolved partner — never appears. FE symptom: *"quand j'accepte ça disparaît et rien ne s'affiche chez Kaicedra dans Mes collaborations."*

Verified on prod: the accept **does** create the collaboration (`collab_status=accepted`), and the exact partner user sees it — but no one else in the org does.

## Fix
Org-scope `scope=self` for org operatives: `collaboration_scope_q(user, 'self')` now returns the user's own collaborations **plus** those of any member of **their organisation** when the user is an `org_admin`/`bureau_agent`. Consistent with the org-scoping of partner suggestions (#59). Users with no org, or non-operatives, are unchanged (exact match). No cross-org leakage (only my own org).

Docs updated in `Dashboardv2/BACKEND_API.md` (+ `.fr.md`).