### PR TITLE
Security: turn off DEBUG in production

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -17,8 +17,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-# À changer quand on le mettra en production
-DEBUG = True
+# DEBUG doit être FALSE en production (fuite de traceback/settings sur toute erreur
+# sinon). Piloté par l'env : par défaut False ; en local, mettre DEBUG=True dans .env.
+DEBUG = os.environ.get("DEBUG", "False").strip().lower() in ("true", "1", "yes", "on")
 
 
 # Split the comma-separated ALLOWED_HOSTS environment variable into a list
@@ -342,6 +343,10 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
+# WhiteNoise sert le statique via les finders même avec DEBUG=False (collectstatic
+# n'est pas lancé au déploiement, donc STATIC_ROOT ne contient pas drf_spectacular
+# _sidecar). Sans ceci, l'UI Swagger/ReDoc perdrait son CSS/JS quand DEBUG=False.
+WHITENOISE_USE_FINDERS = True
 MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
 MEDIA_URL = '/uploads/'
 


### PR DESCRIPTION
## Why
`DEBUG = True` is hardcoded and **live in prod** (`backend/settings.py:21`). Every error renders a full Django debug page (~78 KB) leaking internals — settings, file paths, and on any 500 the full traceback **with local variables** (potential secrets/DB params/tokens). This was actively amplifying a vulnerability-scanner hammering the box (~78 KB × thousands/hr). Django's own guidance: never run DEBUG=True in production.

## Change (settings-only, low risk)
1. **`DEBUG` is now env-driven, default `False`:**
   `DEBUG = os.environ.get("DEBUG", "False").strip().lower() in ("true","1","yes","on")`
   Prod has no `DEBUG` env var (verified: unset in the container, absent from compose + .env) → resolves to **False**. Local dev sets `DEBUG=True` in `.env`.
2. **`WHITENOISE_USE_FINDERS = True`** — the deploy doesn't run `collectstatic`, so `STATIC_ROOT` lacks `drf_spectacular_sidecar`; today Swagger/ReDoc static works only because `DEBUG=True` makes WhiteNoise use finders. This keeps WhiteNoise serving via finders with `DEBUG=False`, so Swagger UI keeps its CSS/JS.

## Safety
- No `ADMINS` set → no error-emails on 500. No code branches on `settings.DEBUG`. `os` already imported.
- The API endpoints don't depend on DEBUG or static — worst case is Swagger *styling*, never an outage.

## Post-deploy checks I'll run
- Bad-Host request returns a **small** 400 (not 78 KB) → DEBUG off.
- Swagger UI static assets load (200).
- API endpoints still 200.