### PR TITLE
Fix map privacy leak (cross-org + deleted incidents) and false collaboration activity

### DIFF
--- a/Mapapi/signals.py
+++ b/Mapapi/signals.py
@@ -6,7 +6,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from .models import (Collaboration, Notification, User, DiscussionMessage, IncidentTask,
-                     UserAction, COLLAB_ROLE_LEADER)
+                     UserAction, COLLAB_ROLE_LEADER, COLLAB_STATUS_ACCEPTED)
 
 
 def _actor_label(user):
@@ -184,7 +184,16 @@ def ws_push_collaboration(sender, instance, created, **kwargs):
         # L'acteur (nom + organisation) est exposé séparément par ActivityFeedSerializer
         # (user_name / organisation_name) ; le texte de l'action ne le répète donc pas.
         incident_title = getattr(getattr(instance, 'incident', None), 'title', None) or "un incident"
-        if created:
+        # Une collaboration de rôle « leader » déjà acceptée n'est PAS une demande :
+        # c'est la prise en charge de l'incident par l'organisation (créée
+        # automatiquement lors du take-in-charge, ou du signalement par un agent de
+        # terrain). La journaliser comme « a demandé une collaboration » publiait une
+        # activité fausse et trompeuse pour chaque incident interne.
+        is_auto_leader = (
+            instance.role == COLLAB_ROLE_LEADER
+            and instance.status == COLLAB_STATUS_ACCEPTED
+        )
+        if created and not is_auto_leader:
             UserAction.objects.create(
                 user=instance.user,
                 action=f"a demandé une collaboration sur l'incident «{incident_title}»."[:255],

--- a/Mapapi/views/incident.py
+++ b/Mapapi/views/incident.py
@@ -1346,9 +1346,19 @@ class IncidentFilterView(APIView):
 
         # Carte du dashboard : on ne tire que les colonnes scalaires utiles aux
         # marqueurs (cf. IncidentMapSerializer) pour éviter le N+1 d'IncidentSerializer.
-        incidents = Incident.objects.only(
-            'id', 'title', 'lattitude', 'longitude', 'etat', 'taken_by',
-            'is_deleted', 'severity', 'created_at',
+        #
+        # `visible_incidents_qs` applique la MÊME portée que la liste /incident/ :
+        #   - exclut les incidents supprimés (is_deleted=True) — sinon la carte
+        #     renvoyait titres et coordonnées d'incidents effacés ;
+        #   - restreint les incidents signalés par un agent de terrain aux membres
+        #     de SON organisation — sinon les signalements internes d'une org
+        #     fuitaient sur la carte de toutes les autres.
+        incidents = visible_incidents_qs(
+            Incident.objects.only(
+                'id', 'title', 'lattitude', 'longitude', 'etat', 'taken_by',
+                'is_deleted', 'severity', 'created_at',
+            ),
+            request.user,
         )
 
         # --- Scope (orthogonal au filtre de date ci-dessous) ---


### PR DESCRIPTION
Reported by the CEO: logged in as **DRH Ménaka**, they could see incidents reported by **Kaicedra Consulting's field agent**, plus activity that should be private, and deleted incidents that 'stay'.

Reproduced on prod with the CEO's own account. Two independent bugs.

## 1. The map endpoint has no privacy scoping (P0)
`IncidentFilterView` queried `Incident.objects` **directly**, bypassing `visible_incidents_qs` — the function the `/incident/` list already uses. It therefore never applied either:
- `is_deleted=False` → deleted incidents were returned (titles + GPS coordinates), and
- the field-agent org scoping → **every org's private field-agent reports were sent to every other org**.

Measured live, as DRH Ménaka:

| Endpoint | Returned |
|---|---|
| `/incident-filter/` (map) | **10** incidents — 7 deleted, 5 of them Kaicedra's private field-agent reports |
| `/incident/` (list, already scoped) | **2** — correct |

The 3 markers actually drawn matched the CEO's "3 incidents affichés": 2 legitimate citizen incidents **+ `e88fcf91` 'Incident Terrain', reported by a Kaicedra field agent** — the leak.

**Fix:** wrap the map queryset in `visible_incidents_qs(..., request.user)`. Verified: `/incident/` already returns exactly the desired result for that user (the 2 citizen incidents, no Kaicedra report, no deleted), so the map now matches.

*Note:* `/org-incidents/` was suggested as the alternative, but it returns **0** incidents for DRH Ménaka and DNACPN (it only covers an org's own interventions, not unclaimed citizen incidents) — switching to it would empty the map and stop orgs from discovering incidents to take on.

## 2. Every internal incident published a false "a demandé une collaboration" (P1)
The `Collaboration` post_save signal logged that activity for **every** row — including the auto-created **leader** collaboration written on take-in-charge and on each field-agent report (#61). Result: the cross-org feed filled with "Kaicedra Consulting SAS a demandé une collaboration…", which is what made field-agent reports look like they 'passent automatiquement en collaboration'.

**Fix:** skip the activity when the row is an auto-created leader collaboration (`role=leader` + `status=accepted`) — taking charge is not requesting a collaboration.

## Verification
`py_compile` clean; AST-parsed both files; confirmed `COLLAB_STATUS_ACCEPTED` is imported and `visible_incidents_qs` is defined (line 55) well before use (line 1356). No behavior change for anonymous map viewers (`is_public` defaults to `True`).