### PR TITLE
Activity feed: never publish internal / field-agent incident activity cross-org

### DIFF
--- a/Mapapi/models.py
+++ b/Mapapi/models.py
@@ -772,6 +772,23 @@ class Incident(UUIDModel):
             return self.user_id.org_role == 'field_agent'
         return False
 
+    @property
+    def is_activity_private(self):
+        """True si l'activité liée à cet incident ne doit PAS être publiée dans le
+        flux d'activité inter-organisations (`/activity-feed/`).
+
+        Deux cas relèvent du travail INTERNE d'une organisation et ne regardent
+        donc pas les autres :
+          - incident pris en charge en mode ``internal`` ;
+          - incident signalé par un agent de terrain (signalement interne à l'org).
+
+        Le flux d'activité reste inter-organisations pour tout le reste (mode
+        collaboratif, signalements citoyens) : c'est sa raison d'être.
+        """
+        if (self.take_in_charge_mode or '').lower() == 'internal':
+            return True
+        return self.reported_by_agent
+
 
 class Evenement(UUIDModel):
     title = models.CharField(max_length=255, blank=True,

--- a/Mapapi/signals.py
+++ b/Mapapi/signals.py
@@ -184,6 +184,12 @@ def ws_push_collaboration(sender, instance, created, **kwargs):
         # L'acteur (nom + organisation) est exposé séparément par ActivityFeedSerializer
         # (user_name / organisation_name) ; le texte de l'action ne le répète donc pas.
         incident_title = getattr(getattr(instance, 'incident', None), 'title', None) or "un incident"
+        # Le flux d'activité est INTER-ORGANISATIONS : on n'y publie jamais le
+        # travail interne d'une org (incident en mode interne ou signalé par un de
+        # ses agents de terrain), sinon son titre fuite chez toutes les autres.
+        inc_obj = getattr(instance, 'incident', None)
+        if inc_obj is not None and inc_obj.is_activity_private:
+            return
         # Une collaboration de rôle « leader » déjà acceptée n'est PAS une demande :
         # c'est la prise en charge de l'incident par l'organisation (créée
         # automatiquement lors du take-in-charge, ou du signalement par un agent de

--- a/Mapapi/views/incident.py
+++ b/Mapapi/views/incident.py
@@ -1800,9 +1800,14 @@ class HandleIncidentView(APIView):
 
         incident.save()
 
-        user_action = UserAction.objects.create(user=user, action=action_message)
+        # Travail interne d'une organisation : pas de publication dans le flux
+        # d'activité inter-organisations (cf. Incident.is_activity_private).
+        user_action = (
+            None if incident.is_activity_private
+            else UserAction.objects.create(user=user, action=action_message)
+        )
         user_data = UserSerializer(user).data
-        action_data = UserActionSerializer(user_action).data 
+        action_data = UserActionSerializer(user_action).data if user_action else None
         return Response({
             "status": "success",
             "message": action_message,
@@ -1938,7 +1943,8 @@ class TakeInChargeView(APIView):
             )
 
             action_message = f"a pris en charge l'incident «{incident.title}» en mode interne."
-            UserAction.objects.create(user=request.user, action=action_message)
+            # Mode INTERNE = travail privé de l'organisation : jamais publié dans le
+            # flux inter-organisations (fuitait le titre de l'incident interne).
 
             return Response({
                 "status": "success",
@@ -2011,7 +2017,8 @@ class TakeInChargeView(APIView):
             ).exclude(user=request.user).update(status='pending')
 
             action_message = f"a pris en charge l'incident «{incident.title}» en tant que leader (mode collaboratif)."
-            UserAction.objects.create(user=request.user, action=action_message)
+            if not incident.is_activity_private:
+                UserAction.objects.create(user=request.user, action=action_message)
 
             return Response({
                 "status": "success",
@@ -2042,7 +2049,8 @@ class TakeInChargeView(APIView):
 
         role_fr = {'contributor': 'contributeur', 'observer': 'observateur', 'leader': 'leader'}.get(role, role)
         action_message = f"a rejoint l'incident «{incident.title}» en tant que {role_fr}."
-        UserAction.objects.create(user=request.user, action=action_message)
+        if not incident.is_activity_private:
+            UserAction.objects.create(user=request.user, action=action_message)
 
         return Response({
             "status": "success",


### PR DESCRIPTION
Follow-up to #67 (option **A**). #67 removed the *false* "a demandé une collaboration" entries; this closes the remaining genuine leak.

## Problem
`/activity-feed/` is **cross-organisation by design** (it deliberately shows *other* orgs' activity). But it was also publishing an org's **internal work**, leaking incident titles. Example currently live in prod:

> `DRACPN(Bandjagara) a pris en charge l'incident «Incident anonyme» en mode interne`

Any other org sees that title. Same for activity on incidents reported by an org's own field agents.

## Fix (write-time, no migration)
`UserAction` has no FK to `Incident`, so this can't be filtered at read time without a schema change. Instead we simply **never write** the entry for private incidents.

New `Incident.is_activity_private` property — true when the incident is either:
- taken in charge in **`internal`** mode, or
- **reported by a field agent** (reuses the existing `reported_by_agent` property).

Applied at every activity write site:
- `signals.py` — collaboration created / accepted / declined (early return; the WebSocket push to the involved parties is untouched, it happens before this block);
- `views/incident.py` — the legacy action endpoint, internal take-in-charge (**entry removed entirely — internal is private by definition**), collaborative leader take-in-charge, and join-as-role.

Collaborative-mode work and citizen incidents keep publishing, so the feed retains its purpose.

## Verification
`py_compile` clean on all 3 files. Checked the two hazards: the legacy action endpoint uses `user_action` in its response, so it now yields `action: null` instead of raising `NameError`; and the removed internal entry left `action_message` intact for the response body.

## ⚠️ Note for the deploy
This is **preventive only**. The 10 stale false entries already in prod remain visible until cleaned up — a one-time `DELETE` on `Mapapi_useraction`, to be run separately with the owner's approval.