### PR TITLE
Fix 500 on incident create: handle Supabase 409 Duplicate on photo upload

### DIFF
--- a/backend/supabase_storage.py
+++ b/backend/supabase_storage.py
@@ -1,5 +1,6 @@
 # backend/supabase_storage.py
 import os
+import uuid
 from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.files.base import ContentFile
@@ -80,15 +81,41 @@ class SupabaseStorage(Storage):
                     # non bloquant
                     print(f"Note: Could not verify/create folder {folder_path}: {e}")
 
+    @staticmethod
+    def _is_duplicate_error(e):
+        """Vrai si l'erreur Supabase est un conflit de nom (409 / Duplicate)."""
+        code = getattr(e, "statusCode", None) or getattr(e, "status_code", None)
+        if str(code) == "409":
+            return True
+        text = f"{getattr(e, 'message', '')} {getattr(e, 'name', '')} {e}".lower()
+        return "duplicate" in text or "already exists" in text or "409" in text
+
+    @staticmethod
+    def _uniquify_name(name):
+        """Ajoute un suffixe aléatoire court avant l'extension."""
+        root, ext = os.path.splitext(name)
+        return f"{root}_{uuid.uuid4().hex[:8]}{ext}"
+
     def _save(self, name, content):
-        try:
-            file_content = content.read()
-            if "/" in name:
-                self._ensure_folder_exists(name)
-            _ = self._get_storage().upload(name, file_content)
-            return name
-        except StorageException as e:
-            raise IOError(f"Error saving file to Supabase Storage: {e}")
+        # `content.read()` UNE seule fois : le pointeur ne se réinitialise pas entre
+        # deux tentatives d'upload.
+        file_content = content.read()
+        if "/" in name:
+            self._ensure_folder_exists(name)
+        # Supabase renvoie 409 "Duplicate" si le nom existe déjà. `exists()` (via
+        # `list()`, paginé) n'est PAS fiable, donc `get_available_name()` peut laisser
+        # passer une collision (ex. photos nommées `images.jpeg`). On uniquifie le nom
+        # et on réessaie plutôt que de renvoyer un 500 sur la création d'incident.
+        attempts = 5
+        for i in range(attempts):
+            try:
+                self._get_storage().upload(name, file_content)
+                return name
+            except StorageException as e:
+                if self._is_duplicate_error(e) and i < attempts - 1:
+                    name = self._uniquify_name(name)
+                    continue
+                raise IOError(f"Error saving file to Supabase Storage: {e}")
 
     def delete(self, name):
         try:


### PR DESCRIPTION
## Problem
`POST /MapApi/incident/` returns **500** when the uploaded photo's filename collides with an existing object in Supabase Storage:
```
OSError: Error saving file to Supabase Storage:
{'statusCode': 409, 'error': Duplicate, 'message': The resource already exists}   (incidents/images.jpeg)
```
The incident is **not saved**, so its AI prediction is never triggered — a dropped report.

**Root cause:** `SupabaseStorage._save` uploads with the given name and re-raises on any error. Django's `get_available_name()` is supposed to avoid collisions via `exists()`, but the custom `exists()` uses Supabase `list()` which is **paginated (~100 items)** — so for a large `incidents/` folder it misses existing files and no unique suffix is added. Generic names (`images.jpeg`, `photo.jpg`, screenshots) then collide → 409 → 500. Random-named uploads (mobile app) are unaffected.

## Fix
`_save` now catches the 409/"Duplicate", appends a short random suffix, and retries (up to 5×) instead of raising. The file content is read once and reused across retries. Protects **every** upload path (incidents, avatars, org logos, field reports, events), independent of the unreliable `exists()`.

## Verified
`py_compile` clean; standalone simulation of the retry + `_is_duplicate_error`/`_uniquify_name` helpers: duplicate detected (no false positive on a 400), collision uniquifies on retry, happy path uploads once with the name unchanged.