### PR TITLE
Fix deploy: pin Compose project name after repo rename (network Pool overlaps)

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -76,9 +76,15 @@ jobs:
 
       - name: Build and Deploy Docker Image
         run: |
-          docker-compose -f _cd_pipeline.yml build
-          docker-compose -f _cd_pipeline.yml down --remove-orphans
-          docker-compose -f _cd_pipeline.yml up --build -d
+          # Pin the Compose project name to `mapapi` (the pre-existing running
+          # stack). The repo was renamed Mapapi -> map-action-api, which changed the
+          # runner checkout dir and thus the default project name -> Compose tried to
+          # create a NEW network on the same fixed subnet (192.168.0.0/24) while the
+          # old `mapapi` network was still up -> "Pool overlaps". Pinning makes `down`
+          # tear down the running stack and `up` recreate it under the same network.
+          docker-compose -p mapapi -f _cd_pipeline.yml build
+          docker-compose -p mapapi -f _cd_pipeline.yml down --remove-orphans
+          docker-compose -p mapapi -f _cd_pipeline.yml up --build -d
 
       - name: Post-deployment cleanup
         if: always()


### PR DESCRIPTION
## Problem
The CI/CD deploy fails at `docker-compose up`:
```
failed to create network map-action-api_micro-services-network:
Error response from daemon: Pool overlaps with other one on this address space
```
**Cause:** the repo was renamed `Mapapi` → `map-action-api`, which changed the self-hosted runner's checkout dir and therefore the **default Compose project name** (`mapapi` → `map-action-api`). The compose network pins a fixed subnet (`192.168.0.0/24`); `down` now targets the empty `map-action-api` project (leaving the old `mapapi` stack running), and `up` tries to create a *new* network on that already-occupied subnet → overlap → deploy fails. Prod stayed up on the old `mapapi` containers (so no outage), but no new code deploys.

## Fix
Pin the Compose project name to `mapapi` on all three commands (`-p mapapi`), so `down` tears down the running stack and `up` recreates it under the **same** network — no new-network conflict. Also makes the deploy immune to future dir/rename changes.

No app-code change. This deploy will also ship the already-merged #71 (storage 409 fix), which is currently stuck behind this.